### PR TITLE
Docs update, formatting fixes

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -1,13 +1,13 @@
 on:
   push:
   schedule:
-    - # ~6am AEST
+    # ~6am AEST
     - cron: "19 19 * * *"
 jobs:
   bump_versions:
     name: Bump Browser Versions
     runs-on:
-      ubuntu-22.04
+      ubuntu-latest
     env:
       # https://stackoverflow.com/a/71158878/2014893
       BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
@@ -18,7 +18,7 @@ jobs:
         if: env.using_self_hosted_runner_with_nix != 'true'
         uses: cachix/install-nix-action@v26
         with:
-          install_url: "https://releases.nixos.org/nix/nix-2.18.1/install"
+          install_url: "https://releases.nixos.org/nix/nix-2.21.0/install"
       - name: Run the Magic Nix Cache # https://determinate.systems/posts/magic-nix-cache
         uses: DeterminateSystems/magic-nix-cache-action@v4
       - name: Check Nix flake inputs

--- a/README.md
+++ b/README.md
@@ -9,24 +9,24 @@ and were dropped in [NixOS/nixpkgs#261870](https://github.com/NixOS/nixpkgs/pull
 
 ## Available packages
 
-Run `nix flake show github:r-k-b/browser-previews` for the up-to-date list.
+Run `nix flake show github:nix-community/browser-previews` for the up-to-date list.
 
 ## How?
 
 ### To directly run latest `google-chrome` from this flake
 
 ```bash
-NIXPKGS_ALLOW_UNFREE=1 nix run github:r-k-b/browser-previews#google-chrome --impure
+NIXPKGS_ALLOW_UNFREE=1 nix run github:nix-community/browser-previews#google-chrome --impure
 ```
 
 Likewise for google-chrome-beta or google-chrome-dev:
 
 ```bash
-NIXPKGS_ALLOW_UNFREE=1 nix run github:r-k-b/browser-previews#google-chrome-beta --impure
+NIXPKGS_ALLOW_UNFREE=1 nix run github:nix-community/browser-previews#google-chrome-beta --impure
 ```
 
 ```bash
-NIXPKGS_ALLOW_UNFREE=1 nix run github:r-k-b/browser-previews#google-chrome-dev --impure
+NIXPKGS_ALLOW_UNFREE=1 nix run github:nix-community/browser-previews#google-chrome-dev --impure
 ```
 
 ### To install a package from this flake
@@ -34,7 +34,7 @@ NIXPKGS_ALLOW_UNFREE=1 nix run github:r-k-b/browser-previews#google-chrome-dev -
 - First you must add it as a input to your `flake.nix`:
 
 ```nix
-inputs.browser-previews = { url = "github:r-k-b/browser-previews";
+inputs.browser-previews = { url = "github:nix-community/browser-previews";
                             inputs.nixpkgs.follows = "nixpkgs"; };
 ```
 

--- a/flake.nix
+++ b/flake.nix
@@ -10,13 +10,23 @@
     systems.url = "github:nix-systems/x86_64-linux";
   };
 
-  outputs = { self, nixpkgs, flake-utils, ... }:
-    flake-utils.lib.eachDefaultSystem (system:
+  outputs =
+    {
+      self,
+      nixpkgs,
+      flake-utils,
+      ...
+    }:
+    flake-utils.lib.eachDefaultSystem (
+      system:
       let
-        pkgs = import nixpkgs { system = "x86_64-linux"; config.allowUnfree = true; };
-        google-chrome = channel:
-          pkgs.callPackage ./google-chrome { inherit channel; };
-      in {
+        pkgs = import nixpkgs {
+          system = "x86_64-linux";
+          config.allowUnfree = true;
+        };
+        google-chrome = channel: pkgs.callPackage ./google-chrome { inherit channel; };
+      in
+      {
         checks = {
           google-chrome = google-chrome "stable";
           google-chrome-beta = google-chrome "beta";
@@ -29,9 +39,13 @@
             buildInputs = with pkgs; [
               nix
               nix-prefetch-git
-              nixfmt
-              (python3.withPackages
-                (p3pkgs: [ p3pkgs.feedparser p3pkgs.requests ]))
+              nixfmt-rfc-style
+              (python3.withPackages (
+                p3pkgs: with p3pkgs; [
+                  feedparser
+                  requests
+                ]
+              ))
             ];
           };
         };
@@ -41,5 +55,6 @@
           google-chrome-beta = google-chrome "beta";
           google-chrome-dev = google-chrome "dev";
         };
-      });
+      }
+    );
 }

--- a/google-chrome/default.nix
+++ b/google-chrome/default.nix
@@ -1,47 +1,100 @@
 # Based on: https://github.com/NixOS/nixpkgs/blob/2c106c1e7c0794927c3b889de51e3c2cdd9130ba/pkgs/applications/networking/browsers/google-chrome/default.nix
-{ fetchurl, lib, stdenv, patchelf, makeWrapper
+{
+  fetchurl,
+  lib,
+  stdenv,
+  patchelf,
+  makeWrapper,
 
-# Linked dynamic libraries.
-, glib, fontconfig, freetype, pango, cairo, libX11, libXi, atk, nss, nspr
-, libXcursor, libXext, libXfixes, libXrender, libXScrnSaver, libXcomposite
-, libxcb, alsa-lib, libXdamage, libXtst, libXrandr, libxshmfence, expat, cups
-, dbus, gtk3, gtk4, gdk-pixbuf, gcc-unwrapped, at-spi2-atk, at-spi2-core
-, libkrb5, libdrm, libglvnd, mesa, libxkbcommon, pipewire
-, wayland # ozone/wayland
+  # Linked dynamic libraries.
+  glib,
+  fontconfig,
+  freetype,
+  pango,
+  cairo,
+  libX11,
+  libXi,
+  atk,
+  nss,
+  nspr,
+  libXcursor,
+  libXext,
+  libXfixes,
+  libXrender,
+  libXScrnSaver,
+  libXcomposite,
+  libxcb,
+  alsa-lib,
+  libXdamage,
+  libXtst,
+  libXrandr,
+  libxshmfence,
+  expat,
+  cups,
+  dbus,
+  gtk3,
+  gtk4,
+  gdk-pixbuf,
+  gcc-unwrapped,
+  at-spi2-atk,
+  at-spi2-core,
+  libkrb5,
+  libdrm,
+  libglvnd,
+  mesa,
+  libxkbcommon,
+  pipewire,
+  wayland, # ozone/wayland
 
-# Command line programs
-, coreutils
+  # Command line programs
+  coreutils,
 
-# command line arguments which are always set e.g "--disable-gpu"
-, commandLineArgs ? ""
+  # command line arguments which are always set e.g "--disable-gpu"
+  commandLineArgs ? "",
 
   # Will crash without.
-, systemd
+  systemd,
 
-# Loaded at runtime.
-, libexif, pciutils
+  # Loaded at runtime.
+  libexif,
+  pciutils,
 
-# Additional dependencies according to other distros.
-## Ubuntu
-, liberation_ttf, curl, util-linux, xdg-utils, wget
-## Arch Linux.
-, flac, harfbuzz, icu, libpng, libopus, snappy, speechd
-## Gentoo
-, bzip2, libcap
+  # Additional dependencies according to other distros.
+  ## Ubuntu
+  liberation_ttf,
+  curl,
+  util-linux,
+  xdg-utils,
+  wget,
+  ## Arch Linux.
+  flac,
+  harfbuzz,
+  icu,
+  libpng,
+  libopus,
+  snappy,
+  speechd,
+  ## Gentoo
+  bzip2,
+  libcap,
 
-# Which distribution channel to use.
-, channel ? "stable"
+  # Which distribution channel to use.
+  channel ? "stable",
 
   # Necessary for USB audio devices.
-, pulseSupport ? true, libpulseaudio
+  pulseSupport ? true,
+  libpulseaudio,
 
-, gsettings-desktop-schemas, gnome
+  gsettings-desktop-schemas,
+  gnome,
 
-# For video acceleration via VA-API (--enable-features=VaapiVideoDecoder)
-, libvaSupport ? true, libva
+  # For video acceleration via VA-API (--enable-features=VaapiVideoDecoder)
+  libvaSupport ? true,
+  libva,
 
-# For Vulkan support (--enable-features=Vulkan)
-, addOpenGLRunpath }:
+  # For Vulkan support (--enable-features=Vulkan)
+  addOpenGLRunpath,
+}:
 
 let
   opusWithCustomModes = libopus.override { withCustomModes = true; };
@@ -50,98 +103,108 @@ let
 
   version = upstream-info.${channel}.version;
 
-  deps = [
-    glib
-    fontconfig
-    freetype
-    pango
-    cairo
-    libX11
-    libXi
-    atk
-    nss
-    nspr
-    libXcursor
-    libXext
-    libXfixes
-    libXrender
-    libXScrnSaver
-    libXcomposite
-    libxcb
-    alsa-lib
-    libXdamage
-    libXtst
-    libXrandr
-    libxshmfence
-    expat
-    cups
-    dbus
-    gdk-pixbuf
-    gcc-unwrapped.lib
-    systemd
-    libexif
-    pciutils
-    liberation_ttf
-    curl
-    util-linux
-    wget
-    flac
-    harfbuzz
-    icu
-    libpng
-    opusWithCustomModes
-    snappy
-    speechd
-    bzip2
-    libcap
-    at-spi2-atk
-    at-spi2-core
-    libkrb5
-    libdrm
-    libglvnd
-    mesa
-    coreutils
-    libxkbcommon
-    pipewire
-    wayland
-  ] ++ lib.optional pulseSupport libpulseaudio
-    ++ lib.optional libvaSupport libva ++ [ gtk3 gtk4 ];
+  deps =
+    [
+      glib
+      fontconfig
+      freetype
+      pango
+      cairo
+      libX11
+      libXi
+      atk
+      nss
+      nspr
+      libXcursor
+      libXext
+      libXfixes
+      libXrender
+      libXScrnSaver
+      libXcomposite
+      libxcb
+      alsa-lib
+      libXdamage
+      libXtst
+      libXrandr
+      libxshmfence
+      expat
+      cups
+      dbus
+      gdk-pixbuf
+      gcc-unwrapped.lib
+      systemd
+      libexif
+      pciutils
+      liberation_ttf
+      curl
+      util-linux
+      wget
+      flac
+      harfbuzz
+      icu
+      libpng
+      opusWithCustomModes
+      snappy
+      speechd
+      bzip2
+      libcap
+      at-spi2-atk
+      at-spi2-core
+      libkrb5
+      libdrm
+      libglvnd
+      mesa
+      coreutils
+      libxkbcommon
+      pipewire
+      wayland
+    ]
+    ++ lib.optional pulseSupport libpulseaudio
+    ++ lib.optional libvaSupport libva
+    ++ [
+      gtk3
+      gtk4
+    ];
 
   suffix = lib.optionalString (channel != "stable") "-${channel}";
 
-  crashpadHandlerBinary = if lib.versionAtLeast version "94" then
-    "chrome_crashpad_handler"
-  else
-    "crashpad_handler";
+  crashpadHandlerBinary =
+    if lib.versionAtLeast version "94" then "chrome_crashpad_handler" else "crashpad_handler";
 
-  pkgSuffix = if channel == "dev" then
-    "unstable"
-  else
-    (if channel == "ungoogled-chromium" then "stable" else channel);
+  pkgSuffix =
+    if channel == "dev" then
+      "unstable"
+    else
+      (if channel == "ungoogled-chromium" then "stable" else channel);
 
   pkgName = "google-chrome-${pkgSuffix}";
-
-in stdenv.mkDerivation {
+in
+stdenv.mkDerivation {
   inherit version;
 
   name = "google-chrome${suffix}-${version}";
 
   # chromeSrc
-  src = let
-    # Use the latest stable Chrome version if necessary:
-    version = upstream-info.${channel}.version;
-    hash = upstream-info.${channel}.hash_deb_amd64;
-  in fetchurl {
-    urls = map (repo: "${repo}/${pkgName}/${pkgName}_${version}-1_amd64.deb") [
-      "https://dl.google.com/linux/chrome/deb/pool/main/g"
-      "http://95.31.35.30/chrome/pool/main/g"
-      "http://mirror.pcbeta.com/google/chrome/deb/pool/main/g"
-      "http://repo.fdzh.org/chrome/deb/pool/main/g"
-    ];
-    inherit hash;
-  };
+  src =
+    let
+      # Use the latest stable Chrome version if necessary:
+      version = upstream-info.${channel}.version;
+      hash = upstream-info.${channel}.hash_deb_amd64;
+    in
+    fetchurl {
+      urls = map (repo: "${repo}/${pkgName}/${pkgName}_${version}-1_amd64.deb") [
+        "https://dl.google.com/linux/chrome/deb/pool/main/g"
+        "http://95.31.35.30/chrome/pool/main/g"
+        "http://mirror.pcbeta.com/google/chrome/deb/pool/main/g"
+        "http://repo.fdzh.org/chrome/deb/pool/main/g"
+      ];
+      inherit hash;
+    };
 
-  nativeBuildInputs = [ patchelf makeWrapper ];
+  nativeBuildInputs = [
+    patchelf
+    makeWrapper
+  ];
   buildInputs = [
     # needed for GSETTINGS_SCHEMAS_PATH
     gsettings-desktop-schemas
@@ -157,8 +220,7 @@ in stdenv.mkDerivation {
     tar xf data.tar.xz
   '';
 
-  rpath = lib.makeLibraryPath deps + ":"
-    + lib.makeSearchPathOutput "lib" "lib64" deps;
+  rpath = lib.makeLibraryPath deps + ":" + lib.makeSearchPathOutput "lib" "lib64" deps;
   binpath = lib.makeBinPath deps;
 
   installPhase = ''
@@ -218,15 +280,12 @@ in stdenv.mkDerivation {
     runHook postInstall
   '';
 
-  meta = with lib; {
+  meta = {
     description = "A freeware web browser developed by Google";
     homepage = "https://www.google.com/chrome/browser/";
-    license = licenses.unfree;
-    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
+    license = lib.licenses.unfree;
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
     platforms = [ "x86_64-linux" ];
-    mainProgram = if (channel == "dev") then
-      "google-chrome-unstable"
-    else
-      "google-chrome-${channel}";
+    mainProgram = if (channel == "dev") then "google-chrome-unstable" else "google-chrome-${channel}";
   };
 }


### PR DESCRIPTION
## Changes
- README: Update the docs to point to the new url `github:nix-community/browser-previews`
- bump.yml: Update nix version in workflow and fix syntax error
- flake.nix: use the new adopted `nixfmt-rfc-style` instead of `nixfmt`, reformat the file
- default.nix: reformatting the file