### PR TITLE
fix: replace the deprecated `addOpenGLRunpath` with `addDriverRunpath`

### DIFF
--- a/google-chrome/default.nix
+++ b/google-chrome/default.nix
@@ -93,7 +93,7 @@
   libva,
 
   # For Vulkan support (--enable-features=Vulkan)
-  addOpenGLRunpath,
+  addDriverRunpath,
 }:
 
 let
@@ -267,7 +267,7 @@ stdenv.mkDerivation {
       --prefix LD_LIBRARY_PATH : "$rpath" \
       --prefix PATH            : "$binpath" \
       --suffix PATH            : "${lib.makeBinPath [ xdg-utils ]}" \
-      --prefix XDG_DATA_DIRS   : "$XDG_ICON_DIRS:$GSETTINGS_SCHEMAS_PATH:${addOpenGLRunpath.driverLink}/share" \
+      --prefix XDG_DATA_DIRS   : "$XDG_ICON_DIRS:$GSETTINGS_SCHEMAS_PATH:${addDriverRunpath.driverLink}/share" \
       --set CHROME_WRAPPER  "google-chrome-$dist" \
       --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations}}" \
       --add-flags ${lib.escapeShellArg commandLineArgs}


### PR DESCRIPTION
`addOpenGLRunpath` was deprecated in [this PR](https://github.com/NixOS/nixpkgs/pull/275241). As of NixOS 25.05, attempting to build Chrome with this flake gives an error due to its deprecation.