### PR TITLE
fix(deps): mesa -> libgbm

### DIFF
--- a/google-chrome/default.nix
+++ b/google-chrome/default.nix
@@ -41,7 +41,7 @@
   libkrb5,
   libdrm,
   libglvnd,
-  mesa,
+  libgbm,
   libxkbcommon,
   pipewire,
   wayland, # ozone/wayland
@@ -153,7 +153,7 @@ let
       libkrb5
       libdrm
       libglvnd
-      mesa
+      libgbm
       coreutils
       libxkbcommon
       pipewire


### PR DESCRIPTION
- **`libgbm` separated from `mesa` in `nixpkgs`**  
  - `libgbm` is now a standalone package, reducing unnecessary dependencies.  

- **Fixes issue #30**