### PR TITLE
Keep build working 2025-09

### DIFF
--- a/google-chrome/default.nix
+++ b/google-chrome/default.nix
@@ -246,9 +246,13 @@ stdenv.mkDerivation {
       --replace-fail /usr/bin/google-chrome-$dist $exe
     substituteInPlace $out/share/gnome-control-center/default-apps/google-$appname.xml \
       --replace-fail /opt/google/$appname/google-$appname $exe
-    substituteInPlace $out/share/menu/google-$appname.menu \
-      --replace-fail /opt $out/share \
-      --replace-fail $out/share/google/$appname/google-$appname $exe
+    if [[ -f $out/share/menu/google-$appname.menu ]]; then
+      substituteInPlace $out/share/menu/google-$appname.menu \
+        --replace-fail /opt $out/share \
+        --replace-fail $out/share/google/$appname/google-$appname $exe
+    else
+        echo "share/menu file missing; paths not replaced."
+    fi;
 
     for icon_file in $out/share/google/chrome*/product_logo_[0-9]*.png; do
       num_and_suffix="''${icon_file##*logo_}"

--- a/google-chrome/default.nix
+++ b/google-chrome/default.nix
@@ -241,14 +241,14 @@ stdenv.mkDerivation {
 
 
     substituteInPlace $out/share/google/$appname/google-$appname \
-      --replace 'CHROME_WRAPPER' 'WRAPPER'
+      --replace-fail 'CHROME_WRAPPER' 'WRAPPER'
     substituteInPlace $out/share/applications/google-$appname.desktop \
-      --replace /usr/bin/google-chrome-$dist $exe
+      --replace-fail /usr/bin/google-chrome-$dist $exe
     substituteInPlace $out/share/gnome-control-center/default-apps/google-$appname.xml \
-      --replace /opt/google/$appname/google-$appname $exe
+      --replace-fail /opt/google/$appname/google-$appname $exe
     substituteInPlace $out/share/menu/google-$appname.menu \
-      --replace /opt $out/share \
-      --replace $out/share/google/$appname/google-$appname $exe
+      --replace-fail /opt $out/share \
+      --replace-fail $out/share/google/$appname/google-$appname $exe
 
     for icon_file in $out/share/google/chrome*/product_logo_[0-9]*.png; do
       num_and_suffix="''${icon_file##*logo_}"

--- a/google-chrome/upstream-info.nix
+++ b/google-chrome/upstream-info.nix
@@ -1,20 +1,20 @@
 {
   beta = {
-    hash_deb_amd64 = "sha256-bKPnEPS2Yyw4TOJ0pBVVR9dla5+T6/7s83R4qa/oB58=";
-    version = "140.0.7339.24";
+    hash_deb_amd64 = "sha256-042ynZgvgQ5MSgiGeTshy/aUHDPl1wwxpS7MldAVgqM=";
+    version = "141.0.7390.30";
   };
   dev = {
-    hash_deb_amd64 = "sha256-5cwNyyVW3CFHHGrlQg/pXyLSWew0SD93lW59uqgbtiw=";
-    version = "141.0.7354.0";
+    hash_deb_amd64 = "sha256-h/lJg79wKfLivOpue4dHELTdMmm+aeHNHMfGljQAir8=";
+    version = "142.0.7420.2";
   };
   stable = {
     chromedriver = {
-      hash_darwin = "sha256-xuKmMNcuABdknVTympPKphf6wPhGwjsr1klNj+kuRHk=";
-      hash_darwin_aarch64 = "sha256-uUYus8MpZ/ta9WGaD84ljSIooQd4feFX/AGX0mTv7Eo=";
-      hash_linux = "sha256-tZQNk9l9o9mNug1PWmcka4OajlY01pptYl0K1Uvti7I=";
-      version = "139.0.7258.138";
+      hash_darwin = "sha256-Nqw2ZR6wwK/kWFTmJt14wlm1OdVMEtSPT5xHaSxGObg=";
+      hash_darwin_aarch64 = "sha256-3iC7u3GiqQL7ONksCOzUOo3YlriWuKtpr3m3SJy7VGQ=";
+      hash_linux = "sha256-9er4hKXcLFn0czL3RlzA3xj6RkSm0WmQs6rlLYirrds=";
+      version = "140.0.7339.185";
     };
-    hash_deb_amd64 = "sha256-PtxTlQhgrGq/e1k/U1V/9zaN9atpg1r0qwp6lgtyaOo=";
-    version = "139.0.7258.138";
+    hash_deb_amd64 = "sha256-cPAbDVevr/vtBwLn+bcPmQHNfLrh+Ogw3rDKV5pwB2M=";
+    version = "140.0.7339.185";
   };
 }


### PR DESCRIPTION
- A "menu" file is no longer included; patching the paths in that file is now skipped if the file is missing.
- Warnings about the deprecated `--replace` argument have been resolved.