### PR TITLE
Add Dependabot for nix flake updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,7 @@ updates:
     open-pull-requests-limit: 3
     reviewers:
       - r-k-b
+  - package-ecosystem: "nix"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
See https://github.blog/changelog/2026-04-07-dependabot-version-updates-now-support-the-nix-ecosystem/